### PR TITLE
Fix usage card message in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ sender = HangoutsChat::Sender.new 'webhook_URL'
 header = { title: 'Pizza Bot Customer Support',
            subtitle: 'pizzabot@example.com',
            imageUrl: 'https://goo.gl/aeDtrS' }
-sections = [{ keyValue: { topLabel: 'Order No.', content: '12345' } },
-            { keyValue: { topLabel: 'Status', content: 'In Delivery' } }]
+sections = [{ widgets: [{ keyValue: { topLabel: 'Order No.', content: '12345' } },
+                        { keyValue: { topLabel: 'Status', content: 'In Delivery' } }] }]
 
 sender.card(header, sections)
 ```

--- a/test/hangouts_chat_test.rb
+++ b/test/hangouts_chat_test.rb
@@ -29,8 +29,8 @@ class HangoutsChatTest < Minitest::Test
     header = { title: 'Pizza Bot Customer Support',
                subtitle: 'pizzabot@example.com',
                imageUrl: 'https://goo.gl/aeDtrS' }
-    sections = [{ keyValue: { topLabel: 'Order No.', content: '12345' } },
-                { keyValue: { topLabel: 'Status', content: 'In Delivery' } }]
+    sections = [{ widgets: [{ keyValue: { topLabel: 'Order No.', content: '12345' } },
+                            { keyValue: { topLabel: 'Status', content: 'In Delivery' } }] }]
 
     @sender.card(header, sections)
 


### PR DESCRIPTION
I fixed it because the usage card message is old.

Please check card formatting messages document.

[Card Formatting Messages](https://developers.google.com/hangouts/chat/reference/message-formats/cards)

Attach a screenshot of a sample of the card formatting messages document.

![card](https://user-images.githubusercontent.com/2187422/40953230-c3d15590-68b9-11e8-83aa-584487de5b05.png)
